### PR TITLE
Update image API from lastImageURL to structured image object

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,3 +36,11 @@ The hook follows a two-step initialization pattern:
 
 Camera states flow through: `WAITING` → `CONNECTED` → `CLOSED`
 The hook manages WebSocket lifecycle automatically, disconnecting when camera closes.
+
+### Image Data Structure
+
+The hook returns image data as a `CameraImage` object with:
+- `id: string` - Unique identifier for the image
+- `url: string` - URL to access the image
+
+Images are received via WebSocket `image_url` events with payload `{ id, url }` and stored as the `image` property in the hook's return value (replacing the previous `lastImageURL` string).

--- a/README.md
+++ b/README.md
@@ -28,13 +28,13 @@ const sessionId = "unique-session-identifier"; // Your application's session ID
 ## Usage
 
 ```typescript
-import { useCamera, CameraState } from "@poscam/use-camera";
+import { useCamera, CameraState, CameraImage } from "@poscam/use-camera";
 
 function CameraComponent({ sessionId, authToken }: { sessionId: string, authToken: string }) {
   const {
     cameraState,
     qrCodeURL,
-    lastImageURL,
+    image,
     error,
     initialize,
     disconnect,
@@ -59,7 +59,7 @@ function CameraComponent({ sessionId, authToken }: { sessionId: string, authToke
     <div>
       <p>Status: {cameraState}</p>
       {qrCodeURL && <img src={qrCodeURL} alt="QR Code" />}
-      {lastImageURL && <img src={lastImageURL} alt="Latest capture" />}
+      {image && <img src={image.url} alt="Latest capture" />}
       <button onClick={retry}>Retry</button>
       <button onClick={disconnect}>Disconnect</button>
       {cameraState === CameraState.CONNECTED && (
@@ -91,12 +91,21 @@ interface UseCameraOptions {
 interface UseCameraReturn {
   cameraState: CameraState;
   qrCodeURL: string;
-  lastImageURL: string | undefined;
+  image: CameraImage | undefined;
   error: string | null;
   initialize: () => Promise<void>;
   disconnect: () => void;
   retry: () => Promise<void>;
   takePicture: () => void;
+}
+```
+
+#### Image Structure
+
+```typescript
+interface CameraImage {
+  id: string;    // Unique identifier for the image
+  url: string;   // URL to access the image
 }
 ```
 
@@ -120,7 +129,8 @@ enum CameraState {
 **State Management:**
 - Loading state is managed through `CameraState.LOADING` instead of a separate `isLoading` boolean
 - Error state is managed through `CameraState.ERROR` with error details available in the `error` property
-- Only the most recent image URL is maintained (`lastImageURL`), not a full history
+- Only the most recent image is maintained (`image`), not a full history
+- Image data includes both an ID and URL for better tracking and management
 
 ### Functions
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@poscam/use-camera",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "React hook for camera functionality with Phoenix WebSocket integration",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,4 +4,5 @@ export {
   type CreateCameraResponse,
   type UseCameraOptions,
   type UseCameraReturn,
+  type CameraImage,
 } from "./types";

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,10 +21,15 @@ export interface UseCameraOptions {
   useHttps?: boolean;
 }
 
+export interface CameraImage {
+  id: string;
+  url: string;
+}
+
 export interface UseCameraReturn {
   cameraState: CameraState;
   qrCodeURL: string;
-  lastImageURL: string | undefined;
+  image: CameraImage | undefined;
   error: string | null;
   initialize: () => Promise<void>;
   disconnect: () => void;

--- a/src/useCamera.test.ts
+++ b/src/useCamera.test.ts
@@ -70,7 +70,7 @@ describe("useCamera", () => {
 
     expect(result.current.cameraState).toBe(CameraState.WAITING);
     expect(result.current.qrCodeURL).toBe("");
-    expect(result.current.lastImageURL).toBe(undefined);
+    expect(result.current.image).toBe(undefined);
     expect(result.current.error).toBe(null);
     expect(typeof result.current.initialize).toBe("function");
     expect(typeof result.current.disconnect).toBe("function");
@@ -273,7 +273,7 @@ describe("useCamera", () => {
     expect(window.fetch).not.toHaveBeenCalled();
   });
 
-  it("should update lastImageURL when multiple image_url events are received", async () => {
+  it("should update image when multiple image_url events are received", async () => {
     const mockResponse = {
       camera: {
         code: "ABC123",
@@ -293,7 +293,7 @@ describe("useCamera", () => {
       await result.current.initialize();
     });
 
-    expect(result.current.lastImageURL).toBe(undefined);
+    expect(result.current.image).toBe(undefined);
 
     // Simulate multiple image_url events
     const imageUrlCallback = mockChannel.on.mock.calls.find(
@@ -301,23 +301,25 @@ describe("useCamera", () => {
     )?.[1];
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image1.jpg" });
+      imageUrlCallback?.({ id: "img1", url: "http://example.com/image1.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image1.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img1",
+      url: "http://example.com/image1.jpg",
+    });
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image2.jpg" });
+      imageUrlCallback?.({ id: "img2", url: "http://example.com/image2.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image2.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img2",
+      url: "http://example.com/image2.jpg",
+    });
   });
 
-  it("should clear lastImageURL on initialize for new session", async () => {
+  it("should clear image on initialize for new session", async () => {
     const mockResponse = {
       camera: {
         code: "ABC123",
@@ -343,20 +345,21 @@ describe("useCamera", () => {
     )?.[1];
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image1.jpg" });
-      imageUrlCallback?.({ url: "http://example.com/image2.jpg" });
+      imageUrlCallback?.({ id: "img1", url: "http://example.com/image1.jpg" });
+      imageUrlCallback?.({ id: "img2", url: "http://example.com/image2.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image2.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img2",
+      url: "http://example.com/image2.jpg",
+    });
 
-    // Re-initialize (new session) - this should clear lastImageURL
+    // Re-initialize (new session) - this should clear image
     await act(async () => {
       await result.current.initialize();
     });
 
-    expect(result.current.lastImageURL).toBe(undefined);
+    expect(result.current.image).toBe(undefined);
   });
 
 
@@ -446,7 +449,7 @@ describe("useCamera", () => {
     expect(mockChannelPush).not.toHaveBeenCalled();
   });
 
-  it("should update lastImageURL when first image is received", async () => {
+  it("should update image when first image is received", async () => {
     const mockResponse = {
       camera: {
         code: "ABC123",
@@ -466,7 +469,7 @@ describe("useCamera", () => {
       await result.current.initialize();
     });
 
-    expect(result.current.lastImageURL).toBe(undefined);
+    expect(result.current.image).toBe(undefined);
 
     // Simulate image_url event
     const imageUrlCallback = mockChannel.on.mock.calls.find(
@@ -474,15 +477,16 @@ describe("useCamera", () => {
     )?.[1];
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image1.jpg" });
+      imageUrlCallback?.({ id: "img1", url: "http://example.com/image1.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image1.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img1",
+      url: "http://example.com/image1.jpg",
+    });
   });
 
-  it("should update lastImageURL to most recent image when multiple images are received", async () => {
+  it("should update image to most recent image when multiple images are received", async () => {
     const mockResponse = {
       camera: {
         code: "ABC123",
@@ -508,25 +512,27 @@ describe("useCamera", () => {
     )?.[1];
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image1.jpg" });
+      imageUrlCallback?.({ id: "img1", url: "http://example.com/image1.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image1.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img1",
+      url: "http://example.com/image1.jpg",
+    });
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image2.jpg" });
+      imageUrlCallback?.({ id: "img2", url: "http://example.com/image2.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image2.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img2",
+      url: "http://example.com/image2.jpg",
+    });
     
-    // lastImageURL should be updated to the most recent
+    // image should be updated to the most recent
   });
 
-  it("should reset lastImageURL to undefined when reinitializing", async () => {
+  it("should reset image to undefined when reinitializing", async () => {
     const mockResponse = {
       camera: {
         code: "ABC123",
@@ -552,22 +558,23 @@ describe("useCamera", () => {
     )?.[1];
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image1.jpg" });
+      imageUrlCallback?.({ id: "img1", url: "http://example.com/image1.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image1.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img1",
+      url: "http://example.com/image1.jpg",
+    });
 
     // Re-initialize (new session)
     await act(async () => {
       await result.current.initialize();
     });
 
-    expect(result.current.lastImageURL).toBe(undefined);
+    expect(result.current.image).toBe(undefined);
   });
 
-  it("should NOT clear lastImageURL when camera state changes to CLOSED", async () => {
+  it("should NOT clear image when camera state changes to CLOSED", async () => {
     const mockResponse = {
       camera: {
         code: "ABC123",
@@ -593,13 +600,14 @@ describe("useCamera", () => {
     )?.[1];
 
     act(() => {
-      imageUrlCallback?.({ url: "http://example.com/image1.jpg" });
-      imageUrlCallback?.({ url: "http://example.com/image2.jpg" });
+      imageUrlCallback?.({ id: "img1", url: "http://example.com/image1.jpg" });
+      imageUrlCallback?.({ id: "img2", url: "http://example.com/image2.jpg" });
     });
 
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image2.jpg",
-    );
+    expect(result.current.image).toEqual({
+      id: "img2",
+      url: "http://example.com/image2.jpg",
+    });
 
     // Simulate state change to CLOSED
     const stateCallback = mockChannel.on.mock.calls.find(
@@ -610,9 +618,10 @@ describe("useCamera", () => {
       stateCallback?.({ state: CameraState.CLOSED });
     });
 
-    // Should NOT clear lastImageURL on close
-    expect(result.current.lastImageURL).toBe(
-      "http://example.com/image2.jpg",
-    );
+    // Should NOT clear image on close
+    expect(result.current.image).toEqual({
+      id: "img2",
+      url: "http://example.com/image2.jpg",
+    });
   });
 });

--- a/src/useCamera.ts
+++ b/src/useCamera.ts
@@ -5,6 +5,7 @@ import {
   CreateCameraResponse,
   UseCameraOptions,
   UseCameraReturn,
+  CameraImage,
 } from "./types";
 
 export function useCamera(options: UseCameraOptions): UseCameraReturn {
@@ -16,7 +17,7 @@ export function useCamera(options: UseCameraOptions): UseCameraReturn {
     CameraState.WAITING,
   );
   const [qrCodeURL, setQrCodeURL] = useState("");
-  const [lastImageURL, setLastImageURL] = useState<string | undefined>(
+  const [image, setImage] = useState<CameraImage | undefined>(
     undefined,
   );
   const [error, setError] = useState<string | null>(null);
@@ -55,7 +56,7 @@ export function useCamera(options: UseCameraOptions): UseCameraReturn {
         .receive("ok", (_resp) => {
           channel.on("state", (payload) => setCameraState(payload.state));
           channel.on("image_url", (payload) => {
-            setLastImageURL(payload.url);
+            setImage({ id: payload.id, url: payload.url });
           });
         })
         .receive("error", (resp) => {
@@ -75,7 +76,7 @@ export function useCamera(options: UseCameraOptions): UseCameraReturn {
 
     setCameraState(CameraState.LOADING);
     setError(null);
-    setLastImageURL(undefined);
+    setImage(undefined);
 
     try {
       const response = await fetchCamera();
@@ -119,7 +120,7 @@ export function useCamera(options: UseCameraOptions): UseCameraReturn {
   return {
     cameraState,
     qrCodeURL,
-    lastImageURL,
+    image,
     error,
     initialize,
     disconnect,


### PR DESCRIPTION
Changes lastImageURL return value to image object with id and url properties for better tracking and management.

- Add CameraImage interface with id and url fields
- Update useCamera hook to return image instead of lastImageURL
- Modify WebSocket event handler to expect {id, url} payload
- Update all tests to use new image structure
- Update README and CLAUDE.md documentation

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>
